### PR TITLE
Impoper release of foo_object

### DIFF
--- a/samples/kobject/kset-example.c
+++ b/samples/kobject/kset-example.c
@@ -266,10 +266,11 @@ static int __init example_init(void)
 	return 0;
 
 baz_error:
-	destroy_foo_obj(bar_obj);
+	destroy_foo_obj(baz_obj);
 bar_error:
-	destroy_foo_obj(foo_obj);
+	destroy_foo_obj(bar_obj);
 foo_error:
+	destroy_foo_obj(foo_obj);
 	kset_unregister(example_kset);
 	return -EINVAL;
 }


### PR DESCRIPTION
fixed line 268 to 273: foo baz bar error's had improper object destruction. These were fixed by implementing a proper destroy foo_object against correct object